### PR TITLE
[fix] correclty decode string from tcpdevice

### DIFF
--- a/dataprovider/datadevice/tcpdevice.py
+++ b/dataprovider/datadevice/tcpdevice.py
@@ -50,7 +50,7 @@ class TcpDevice(DataDevice):
 
     def readLine(self):
         if self.iodevice.canReadLine():
-            return str(self.iodevice.readLine())
+            return self.iodevice.readLine().data().decode("ASCII")
         return ''
 
     @pyqtSlot()


### PR DESCRIPTION
Hi, 

Thanks a lot for this great qgis plugin.

I had an issue when a read GAPS data from a tcp device using QGIS 3. The first two characters of the string send to the parser are b"

This is the output of the data provider dump tool:
b'$PTSAG,#00203,063048.305,xx,xx,xxxx,0,xxxx.xxxx,x,xxxxx.xxxxx,W,F,0000.0,0,0000.0*3E\r\r\n'
b'$PTSAG,#00204,063049.307,xx,xx,xxxx,0,xxxx.xxxx,x,xxxxx.xxxxx,W,F,0000.0,0,0000.0*32\r\r\n

I fixed the issue by correctly converting data from the QByteArray into string.
