### PR TITLE
force category 'Name' to be read as string not int or float

### DIFF
--- a/posiview_project.py
+++ b/posiview_project.py
@@ -156,7 +156,10 @@ class PosiViewProject(object):
             s.setArrayIndex(i)
             mobile = dict()
             for k in s.childKeys():
-                mobile[k] = self.convertToBestType(s.value(k))
+                if k != 'Name':
+                    mobile[k] = self.convertToBestType(s.value(k))
+                else:
+                    mobile[k] = str(s.value(k))
             properties['Mobiles'][mobile['Name']] = mobile
         s.endArray()
 
@@ -166,7 +169,10 @@ class PosiViewProject(object):
             s.setArrayIndex(i)
             provider = dict()
             for k in s.childKeys():
-                provider[k] = self.convertToBestType(s.value(k))
+                if k != 'Name':
+                    provider[k] = self.convertToBestType(s.value(k))
+                else:
+                    provider[k] = str(s.value(k))
             properties['Provider'][provider['Name']] = provider
         s.endArray()
         properties['Mission'] = dict()


### PR DESCRIPTION
Hi jrenken,
thanks for providing this plugin. I enjoyed it very much while working on R/V Sonne.
I was confronted with a small but problematic issue :
If you give one of your mobiles a name that can be interpreted as number (eg. 1234) and then restart QGis, it will be impossible to use the PosiView plugin from that moment on.
This fixed the issue for me.
Hope it helps and all the best,
Peter
