### PR TITLE
modify decodeVtg() in case VTG comes with knots instead of km/h

### DIFF
--- a/dataprovider/dataparser/parser_gps.py
+++ b/dataprovider/dataparser/parser_gps.py
@@ -94,9 +94,14 @@ class GpsParser(Parser):
         nmea = NmeaRecord(data)
         if nmea.valid:
             try:
-                result = {'course': nmea.value(1),
-                          'speed': nmea.value(7) / 3.6,
-                          'id': nmea[0][1:3]}
+                if nmea.value(7):
+                    result = {'course': nmea.value(1),
+                              'speed': nmea.value(7) / 3.6,
+                              'id': nmea[0][1:3]}
+                else:
+                    result = {'course': nmea.value(1),
+                              'speed': nmea.value(5) / 1.944,
+                              'id': nmea[0][1:3]}
                 return dict((k, v) for k, v in result.items() if v is not None)
             except ValueError:
                 return {}


### PR DESCRIPTION
I'm on RV Polarstern and we have a NMEA stream from DSHIP where the VTG sentence does not contain speed in km/h in field 7, but only knots in field 5. The changes to decodeVtg() check if a value in field 7 is present. If not it will take field 5 and convert knots to m/s so the result is the same.