### PR TITLE
Strip custom prefix from actual data stream sentence

### DIFF
--- a/dataprovider/dataparser/parser_cp16.py
+++ b/dataprovider/dataparser/parser_cp16.py
@@ -21,7 +21,9 @@ class CP16Parser(Parser):
         super(CP16Parser, self).__init__()
 
     def parse(self, data):
-        if data.startswith('$PCI'):
+        idx = data.find('$PCI')
+        if idx != -1:
+            data = data[idx:]
             nmea = NmeaRecord(data)
             if nmea.valid:
                 try:

--- a/dataprovider/dataparser/parser_gps.py
+++ b/dataprovider/dataparser/parser_gps.py
@@ -24,17 +24,20 @@ class GpsParser(Parser):
         super(GpsParser, self).__init__()
 
     def parse(self, data):
-        data_id = data[3:6]
-        if data_id == 'RMC':
-            return self.decodeRmc(data)
-        elif data_id == 'VTG':
-            return self.decodeVtg(data)
-        elif data_id == 'GLL':
-            return self.decodeGll(data)
-        elif data_id == 'GGA':
-            return self.decodeGga(data)
-        elif data_id == 'HDT':
-            return self.decodeHdt(data)
+        idx = data.find('$GP')
+        if idx != -1:
+            data = data[idx:]
+            data_id = data[3:6]
+            if data_id == 'RMC':
+                return self.decodeRmc(data)
+            elif data_id == 'VTG':
+                return self.decodeVtg(data)
+            elif data_id == 'GLL':
+                return self.decodeGll(data)
+            elif data_id == 'GGA':
+                return self.decodeGga(data)
+            elif data_id == 'HDT':
+                return self.decodeHdt(data)
 
     def decodeRmc(self, data):
         nmea = NmeaRecord(data)

--- a/dataprovider/dataparser/parser_minipos.py
+++ b/dataprovider/dataparser/parser_minipos.py
@@ -23,7 +23,9 @@ class MiniPosParser(Parser):
         super(MiniPosParser, self).__init__()
 
     def parse(self, data):
-        if data.startswith('$PSAAS'):
+        idx = data.find('$PSAAS')
+        if idx != -1:
+            data = data[idx:]
             nmea = NmeaRecord(data)
             if nmea.valid:
                 try:

--- a/dataprovider/dataparser/parser_pise.py
+++ b/dataprovider/dataparser/parser_pise.py
@@ -19,7 +19,9 @@ class PiseParser(Parser):
         super(PiseParser, self).__init__()
 
     def parse(self, data):
-        if data.startswith('$PISE'):
+        idx = data.find('$PISE')
+        if idx != -1:
+            data = data[idx:]
             nmea = NmeaRecord(data)
             if nmea.valid:
                 try:

--- a/dataprovider/dataparser/parser_pmtm.py
+++ b/dataprovider/dataparser/parser_pmtm.py
@@ -29,13 +29,16 @@ class PmtmParser(Parser):
         super(PmtmParser, self).__init__()
 
     def parse(self, data):
-        data_id = data[5:8]
-        if data_id == 'GPO':
-            return self.decodeGpo(data)
-        elif data_id == 'ATT':
-            return self.decodeAtt(data)
-        elif data_id == 'SPD':
-            return self.decodeSpd(data)
+        idx = data.find('$PMTM')
+        if idx != -1:
+            data = data[idx:]
+            data_id = data[5:8]
+            if data_id == 'GPO':
+                return self.decodeGpo(data)
+            elif data_id == 'ATT':
+                return self.decodeAtt(data)
+            elif data_id == 'SPD':
+                return self.decodeSpd(data)
 
     def decodeGpo(self, data):
         nmea = NmeaRecord(data)

--- a/dataprovider/dataparser/parser_ranger2.py
+++ b/dataprovider/dataparser/parser_ranger2.py
@@ -25,10 +25,13 @@ class Ranger2Parser(Parser):
         super(Ranger2Parser, self).__init__()
 
     def parse(self, data):
-        if data.startswith('$PSONLLD'):
-            return self.decodeLld(data)
-        elif data.startswith('$PSONALL'):
-            return self.decodeAll(data)
+        idx = data.find('$PSON')
+        if idx != -1:
+            data = data[idx:]
+            if data.startswith('$PSONLLD'):
+                return self.decodeLld(data)
+            elif data.startswith('$PSONALL'):
+                return self.decodeAll(data)
 
     def decodeLld(self, data):
         nmea = NmeaRecord(data)


### PR DESCRIPTION
Hi Jens, thanks for your great plugin!

I recently participated in a research voyage on RV Nathaniel B Palmer where the incoming GPS string was prefixed with a custom timestamp before it was sent into the network.
So, I added a couple of lines to find the actual start of the data stream sentence using the protocol-specific identifier (e.g., `$GP`).

Hope this contribution fixes the odd case where only a "dirty" data stream is available.